### PR TITLE
Trusted publishing

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -8,6 +8,7 @@ runs:
       with:
         node-version: lts/*
         cache: pnpm
+        registry-url: 'https://registry.npmjs.org'
     - name: Install deps
       run: pnpm install
       shell: bash

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -9,6 +9,9 @@ runs:
         node-version: lts/*
         cache: pnpm
         registry-url: 'https://registry.npmjs.org'
+    - name: Update npm to latest (for trusted publishing)
+      run: npm i -g npm@latest
+      shell: bash
     - name: Install deps
       run: pnpm install
       shell: bash

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -36,7 +36,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Rust
-      uses: Boshen/setup-rust@main
+      uses: oxc-project/setup-rust@f78b3964e121f889426634f0eaeeb09fccecac08 # v1.0.6
       with:
         components: ${{ inputs.components }}
         tools: ${{ inputs.tools }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-rust
+        with:
+          components: clippy rustfmt
       - run: cargo fmt --all --check
       - run: cargo clippy --all
       - run: cargo test --all

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   release:
@@ -17,12 +17,4 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-node
 
-      - name: Set Publishing Config
-        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: pnpm publish --no-git-checks --tag latest --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configure Node setup to use the public npm registry and upgrade npm to latest before installing dependencies.
  * Streamline release workflow by removing explicit publishing config and related environment variables; publish step retained.
  * Minor workflow tag syntax adjustment.
  * Pin Rust setup action and enable clippy and rustfmt components in CI.

* **Notes**
  * No user-facing changes or feature impacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->